### PR TITLE
tweak input-many styling

### DIFF
--- a/taglibs/forms.dryml
+++ b/taglibs/forms.dryml
@@ -27,7 +27,7 @@
   <% required ||= "" ; required = comma_split(required.gsub('-', '_')) -%>
   <div merge-attrs="&attributes - attrs_for(:with_fields)">
     <legend param if="&all_parameters[:legend]" />
-    <with-fields-grouped merge-attrs="&attributes & attrs_for(:with_fields)" size="&size" columns="&columns">
+    <with-fields-grouped merge-attrs="&attributes & attrs_for(:with_fields)" size="&size" columns="&columns" param>
 
     <% field_name = this_field_name
        input_attrs = {:no_edit => no_edit} if tag == "input" && no_edit == "disable"
@@ -86,7 +86,7 @@ Supports all attributes supported by `<with-fields>` plus:
   field_names_groups = field_names.in_groups(columns, false)
   row_classes = "row"
   row_classes += " columns" if columns > 1
-  %><div class="#{row_classes}"> <%
+  %><div class="#{row_classes}" merge-attrs> <%
   field_names_groups.each do |field_names_group|
     %> <div class="span#{span_size}"> <%
     field_names_group.each do |field|

--- a/taglibs/input_many.dryml
+++ b/taglibs/input_many.dryml
@@ -1,0 +1,5 @@
+<extend tag="input-many">
+  <old-input-many merge>
+    <field-list: size="0"/>
+  </old-input-many>
+</extend>

--- a/vendor/assets/stylesheets/hobo_bootstrap/hobo_bootstrap_main.scss
+++ b/vendor/assets/stylesheets/hobo_bootstrap/hobo_bootstrap_main.scss
@@ -71,12 +71,14 @@ div.hidden-fields {
 ul.input-many {list-style-type: none;}
 ul.input-all  {list-style-type: none;}
 
-ul.input-many > li { overflow:hidden; zoom:1;}
-ul.input-many .input-many-item {float:left;}
-ul.input-many div.buttons {float:left; margin-left:10px;}
-li.input-many-template { display:none; }
-
-
+ul.input-many > li { display: table-row; }
+ul.input-many > li > div.input-many-item {display: table-cell; padding-right: 10px; padding-top: 20px; border-right: 1px dotted; border-bottom: 1px dotted; }
+/* li:nth-child(3) is the first visible child; first two are hidden */
+ul.input-many > li:nth-child(3) > div.input-many-item {padding-top: 0px;}
+ul.input-many > li > div.buttons {display: table-cell; padding-left: 10px; vertical-align: middle;}
+ul.input-many > li > div.buttons button {@extend .btn}
+ul.input-many > li.input-many-template { display:none; }
+ul.input-many > li.hidden { display:none; }
 
 
 /* Index page fix */


### PR DESCRIPTION
I redid the input-many CSS to use a style more similar (but better) than the clean theming.  The biggest motivation was to make nested input-many's look OK.  You can check an example of this in agility_bootstrap: /users/1/projects/new
