### PR TITLE
hobo model index page shows the "name" column always as first. 

### DIFF
--- a/taglibs/index_page.dryml
+++ b/taglibs/index_page.dryml
@@ -83,9 +83,9 @@ and your controller like this
           if can_edit?(this.first, field_names[0])
             field_names << "actions"
           end
-          # I assume that field_names contains strings
-          # and that name_attribute returns a symbol
-          field_names.delete(klass.name_attribute)
+          # force to work only with strings
+	  field_names.map!(&:to_s)
+          field_names.delete(klass.name_attribute.to_s)
           field_names.unshift("this")
           field_names = field_names.join(', ')
         end


### PR DESCRIPTION
this pull request fixes the following bug:
on the hobo model index page the first column was always set to the "name" column. In the case that the :name field did not exist, the first field was overridden and disappeared.

My patch assumes the following:
- that field_names contains strings  
- that name_attribute returns a symbol 

note: on the page http://hobocentral.net/manual/model#name
name_attribute returns a symbol.
I think in the current release only a string is returned.

I did not write any tests for this patch
